### PR TITLE
3.8.x updates

### DIFF
--- a/Github/cache.py
+++ b/Github/cache.py
@@ -19,7 +19,7 @@ class _BaseCache(UserDict[K, V]):
 
     def __init__(self, max_size: int, *args: Any) -> None:
         self._max_size: int = max(min(max_size, 15), 0)  # bounding max_size to 15 for now
-        self._lru_keys: Deque[K] = deque[K](maxlen=self._max_size)
+        self._lru_keys: Deque[K] = deque(maxlen=self._max_size)
         super().__init__(*args)
 
     def __getitem__(self, __k: K) -> V:

--- a/Github/cache.py
+++ b/Github/cache.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections import deque, UserDict
-from typing import Any, Deque, Tuple, TypeVar
+from collections import deque
+from typing import Any, Deque, Tuple, TypeVar, Dict
 
 __all__: Tuple[str, ...] = ('ObjectCache',)
 
@@ -12,7 +12,7 @@ K = TypeVar('K')
 V = TypeVar('V')
 
 
-class _BaseCache(UserDict[K, V]):
+class _BaseCache(Dict[K, V]):
     """This is a rough implementation of an LRU Cache using a deque and a dict."""
 
     __slots__: Tuple[str, ...] = ('_max_size', '_lru_keys')


### PR DESCRIPTION
PR adjusts for exception below as well as fixing deque typehints for python 3.8.x
```python
Traceback (most recent call last):
  File "/home/var/Github-Api-Wrapper/test.py", line 2, in <module>
    import github
  File "/home/var/Github-Api-Wrapper/github/__init__.py", line 9, in <module>
    from .client import *
  File "/home/var/Github-Api-Wrapper/github/client.py", line 26, in <module>
    from .cache import ObjectCache
  File "/home/var/Github-Api-Wrapper/github/cache.py", line 15, in <module>
    class _BaseCache(UserDict[K, V]):
TypeError: 'ABCMeta' object is not subscriptable
```